### PR TITLE
Fix packages.json and remove redundant information

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3,18 +3,14 @@
     "packages": [
         {
             "name": "Erlyman",
-            "description": "Erlang manual pages navigation",
-            "author": "Mendor",
-            "last_modified": "2014-04-22 07:00:00",
             "details": "https://github.com/Mendor/sublime-erlyman",
-            "readme": "https://raw.githubusercontent.com/Mendor/sublime-erlyman/master/README.md",
             "labels": ["documentation"],
             "releases": [
                 {
                     "version": "0.21",
                     "sublime_text": "*",
                     "platforms": ["osx", "linux"],
-                    "details": "https://github.com/Mendor/sublime-erlyman/tree/master",
+                    "date": "2014-04-22 07:00:00",
                     "url": "https://nodeload.github.com/Mendor/sublime-erlyman/zip/0.21"
                 }
             ]


### PR DESCRIPTION
`last_modified` is not legal how you use it, it should be in the release as `date`.

Furthermore, I removed all keys that are redundant because Package Control defaults to those anyway.

Also, why don't you use the automated tag crawling? You are already pushing tags for new releases anyway, you only have to append another number because currently they are not [semver](http://semver.org)-comform and just specify `"details": "https://github.com/Mendor/sublime-erlyman/tags"` in your release while removing version, date and url.

Refer to https://github.com/wbond/sublime_package_control/tree/master/example-repository.json.
